### PR TITLE
#29 Improve Docker Compose workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh    text eol=lf

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,4 @@ dist: clean ## builds source and wheel package
 	ls -l dist
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py install
+	python setup.py install --user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: '3.8'
 
 services:
+  prerun:
+    image: 'terra_algo_backtest-prerun:latest'
+    container_name: 'terra_algo_backtest-prerun-latest'
+    build:
+      dockerfile: './ops/Dockerfile'
+      target: prerun.env
+      context: '.'
+    volumes:
+      - .:/app/
+    entrypoint: [
+      "bash",
+      "-c",
+      "source '/app/ops/scripts.sh' && ops::shasums::refresh_docker_compose_env_tags"
+    ]
   env:
     image: 'terra_algo_backtest-env:${ENV_TAG}'
     container_name: 'terra_algo_backtest-env-${ENV_TAG}'
@@ -8,6 +22,8 @@ services:
       dockerfile: './ops/Dockerfile'
       target: 'python.env'
       context: '.'
+    depends_on:
+      - prerun
   deps:
     image: 'terra_algo_backtest-deps:${DEPS_TAG}'
     container_name: 'terra_algo_backtest-deps-${DEPS_TAG}'

--- a/ops/Dockerfile
+++ b/ops/Dockerfile
@@ -1,5 +1,27 @@
 ARG DEPS_IMAGE=ustc_invalid_deps_image
 
+# -----------------------------------------------------------------------------
+
+FROM alpine:3.18.2 AS prerun.env
+
+WORKDIR '/app/'
+
+RUN apk update
+RUN apk add --no-cache \
+  bash \
+  git \
+  openssl
+
+RUN addgroup --system 'ustc-untrusted'
+RUN adduser --ingroup 'ustc-untrusted' --system 'ustc-prerun'
+RUN chown -R 'ustc-prerun:ustc-untrusted' '/app/'
+
+USER 'ustc-prerun'
+
+RUN git config --global --add safe.directory '/app'
+
+# -----------------------------------------------------------------------------
+
 FROM python:3.11.4-alpine3.18 AS python.env
 
 WORKDIR '/app/'

--- a/ops/scripts.sh
+++ b/ops/scripts.sh
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 set -f -o pipefail
 
-script_dir="$( dirname -- "$( readlink -f -- "${0}"; )"; )"
+source_dir="$( dirname -- "$( readlink -f -- "${0}"; )"; )"
 
 # Usage:
 # ops::shasums::gen_from_file 'README.md'
@@ -30,23 +30,22 @@ ops::shasums::gen_from_file () {
 }
 
 ops::shasums::gen_from_current_git_commit_hash () {
-  local -r project_dir="${script_dir}/.."
-  local -r git_commit_id="$(git -C "${project_dir}" rev-parse HEAD)"
+  local -r git_commit_id="$(git -C "${source_dir}" rev-parse HEAD)"
   echo "${git_commit_id:0:8}"
 }
 
 ops::shasums::refresh_docker_compose_env_tags () {
-  local -r env_file="${script_dir}/Dockerfile"
+  local -r env_file="${source_dir}/ops/Dockerfile"
   local -r env_hash="$(ops::shasums::gen_from_file "${env_file}")"
 
-  local -r deps_file="${script_dir}/../requirements_dev.txt"
+  local -r deps_file="${source_dir}/requirements_dev.txt"
   local -r deps_hash="$(ops::shasums::gen_from_file "${deps_file}")"
 
   local -r build_hash="$(ops::shasums::gen_from_current_git_commit_hash)"
 
-  local -r compose_env_file="${script_dir}/../.env"
+  local -r compose_env_file="${source_dir}/.env"
 
-  echo "script_dir: ${script_dir}"
+  echo "source_dir: ${source_dir}"
 
   echo "env_hash: ${env_hash}"
   echo "deps_hash: ${deps_hash}"

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 requirements = [
-    "bokeh==2.4.3",
+    "bokeh==3.2.0",
     "loguru==0.6.0",
-    "numpy==1.23.1",
+    "numpy==1.25.1",
     "terra-sdk==2.0.6",
     "terra-proto==1.0.1",
 ]

--- a/terra_algo_backtest/plotting.py
+++ b/terra_algo_backtest/plotting.py
@@ -9,7 +9,7 @@ import scipy
 from bokeh.io import show
 from bokeh.layouts import gridplot, layout
 from bokeh.models import ColumnDataSource, Div, HoverTool, NumeralTickFormatter
-from bokeh.plotting import Figure, figure
+from bokeh.plotting import figure, figure
 from bokeh.transform import dodge
 from statsmodels.tsa.vector_ar.vecm import coint_johansen
 
@@ -29,7 +29,7 @@ def new_constant_product_figure(
     x_min: float | None = None,
     x_max: float | None = None,
     num: int | None = None,
-    bokeh_figure: Figure | None = None,
+    bokeh_figure: figure | None = None,
     plot_width=900,
     plot_height=600,
 ):
@@ -89,7 +89,7 @@ def new_price_impact_figure(
     x_max: float | None = None,
     num: int | None = None,
     precision: float | None = None,
-    bokeh_figure: Figure | None = None,
+    bokeh_figure: figure | None = None,
     plot_width=900,
     plot_height=600,
 ):


### PR DESCRIPTION
This PR makes it so that bootstrapping a local development environment for `terra_algo_backtest` is as close to simple as it can be with our current CI / CD pipeline, regardless of the host environment. Now all that should be needed to run the project is two simple docker compose commands.

### Testing

```
docker-compose up prerun
docker-compose up
```

### Intended Results
- [ ] A docker image and container labelled `terra_algo_backtest-prerun` should be generated, as well as a .env file in the project root that contains dynamically generated environment variables for the `ENV_TAG`, `DEPS_TAG`, and `BUILD_TAG` keys.
- [ ] A docker image and container labelled `terra_algo_backtest-env` with a tag matching the `ENV_TAG` value in the .env file should be successfully created.
- [ ] A docker image and container labelled `terra_algo_backtest-deps` with a tag matching the `DEPS_TAG` value in the .env file should be successfully created.
- [ ] A docker image and container labelled `terra_algo_backtest-build` with a tag matching the `BUILD_TAG` value in the .env file should be successfully created.

### Notes
If you need to regenerate the .env file for whatever reason, you can do so by simply running the following command:
```
docker-compose up prerun
```